### PR TITLE
doc:use of maxfiles  will raise a vuejs warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ new Vue({
 ```
 
 ```html
-<upload-image url="" name="" max_files=""></upload-image>
+<upload-image url="" name=""></upload-image>
 ```
 
 ```css


### PR DESCRIPTION
<upload-image url="" name="" max_files=""></upload-image>
Use of max_files prop will raise a warning in console. max_files is defined as a Number and is valued in the doc as a string.
A workaround I've found, is to  bind it , in the parent :   v-bind:max_files="maxfiles"