### PR TITLE
added images uploading alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+#### 1.1.3
+ * Added images uploading alternative
 #### 1.1.2
 
  * README & LICENSE adjustments.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ new Vue({
 * upload-image-attempt -> [FormData]
 * upload-image-success -> [FormData, Response]
 * upload-image-failure -> [FormData, Response] 
+* upload-images -> [Images] (make sure to override ```custom_submit``` prop to ```true```)
 
 ## Configuration
 ```js
@@ -61,6 +62,11 @@ url: { // upload url
     type: String,
     required: true,
     default: null
+},
+custom_submit: { //to override default uploading
+    type: Boolean,
+    required: false,
+    default: false
 },
 name: { // name to use for FormData
     type: String,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-upload-image",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Configurable image preview & ajax up-loader",
   "main": "dist/upload_image.vue",
   "repository": {


### PR DESCRIPTION
Given the issues i saw both on [open ](https://github.com/viral-vector/vue-upload-image/issues/4)and [closed ](https://github.com/viral-vector/vue-upload-image/issues/2)issues users want a way to upload the images their own way. I wanna do that as well because i have some logic to run before submitting. 

I have found a way to extend the package to enable users to access their images before uploading. They will then have to add a few lines of code to win it:

```js
// on the component
<upload-image url="" name="" :custom_submit="true" @upload-images="uploadImages" :max_files="5"></upload-image>

//on the methods object
uploadImages(images){
  //where images is the images on the canvas
}
```
